### PR TITLE
fix: handle running eslint within a monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 .vscode
+.idea

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -7,12 +7,13 @@ exports.configs = exports.rules = void 0;
 const node_fs_1 = __importDefault(require("node:fs"));
 const node_path_1 = __importDefault(require("node:path"));
 const eslint_1 = __importDefault(require("eslint"));
+const app_root_path_1 = __importDefault(require("app-root-path"));
 const utils_1 = __importDefault(require("./utils"));
 const linter = new eslint_1.default.Linter();
 exports.rules = {};
 const builtIns = {};
 const importedPlugins = [];
-const dirname = node_path_1.default.resolve();
+const dirname = app_root_path_1.default.toString();
 const nodeModules = 'node_modules/';
 const getBuiltIn = node_fs_1.default
     .readdirSync(node_path_1.default.join(dirname, nodeModules, 'eslint/lib/rules'))

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "app-root-path": "^3.1.0",
     "eslint": "^8.16.0",
     "eslint-rule-composer": "^0.3.0"
   },

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import eslint from 'eslint';
+import appRoot from 'app-root-path';
 
 import getNonFixableRule from './utils';
 
@@ -12,7 +13,7 @@ const importedPlugins: {
   rules: { [key: string]: eslint.Rule.RuleModule };
   id: string;
 }[] = [];
-const dirname = path.resolve();
+const dirname = appRoot.toString();
 const nodeModules = 'node_modules/';
 
 const getBuiltIn = fs


### PR DESCRIPTION
Hey there,

Thanks for this great plugin! We ran into one issue when running this plugin inside an nx monorepo where it uses the wrong path to find node_modules. We fix this by using the `app-root-path` package to find the path instead (search up the tree until a node_modules + package.json is found).