### PR TITLE
fix: handle more types of scoped eslint plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 .vscode
+.idea

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -34,25 +34,30 @@ const getPlugins = node_fs_1.default
     plugin !== 'eslint-plugin-disable-autofix' &&
     plugin !== '@eslint');
 for (const plugin of getPlugins) {
-    let copyIt = plugin;
     if (plugin.includes('@')) {
-        const pluginDirectory = node_fs_1.default
+        const pluginDirectories = node_fs_1.default
             .readdirSync(node_path_1.default.join(dirname, nodeModules, plugin))
-            .find((read) => /plugin/u.test(read));
-        if (pluginDirectory) {
-            copyIt = node_path_1.default.join(dirname, nodeModules, plugin, pluginDirectory);
-        }
+            .filter((read) => /plugin/u.test(read));
+        pluginDirectories.forEach((pluginDirectory) => {
+            const scopedPlugin = node_path_1.default.join(dirname, nodeModules, plugin, pluginDirectory);
+            const imported = require(scopedPlugin);
+            imported.id = scopedPlugin.replace(node_path_1.default.join(dirname, nodeModules), '');
+            importedPlugins.push(imported);
+        });
     }
-    const imported = require(copyIt);
-    imported.id = plugin;
-    importedPlugins.push(imported);
+    else {
+        const imported = require(plugin);
+        imported.id = plugin;
+        importedPlugins.push(imported);
+    }
 }
 for (const plugin of importedPlugins) {
     const pluginRules = plugin.rules;
     const pluginId = plugin.id;
     if (pluginId) {
         const pluginName = pluginId.includes('@')
-            ? pluginId.split('/')[0]
+            ?
+                pluginId.replace(/eslint-plugin(-|)/u, '').replace(/\/$/, '')
             : pluginId.replace(/^eslint-plugin-/u, '');
         for (const rule of Object.keys(pluginRules || {})) {
             if (rule) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint-rule-composer": "^0.3.0"
   },
   "devDependencies": {
-    "@mikey-pro/style-guide": "^4.13.16",
+    "@mikey-pro/style-guide": "^4.14.0",
     "@types/eslint": "^8.4.2",
     "prettier": "^2.6.2",
     "stylelint": "^14.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-disable-autofix",
-  "version": "2.13.0",
+  "version": "3.0.0",
   "description": "Disable ESLint autofix (--fix) for specified rules",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -5,13 +5,15 @@ import eslint from 'eslint';
 
 import getNonFixableRule from './utils';
 
+interface EslintPlugin {
+  rules: { [key: string]: eslint.Rule.RuleModule };
+  id: string;
+}
+
 const linter = new eslint.Linter();
 export const rules: { [key: string]: eslint.Rule.RuleModule } = {};
 const builtIns: { [key: string]: NodeModule } = {};
-const importedPlugins: {
-  rules: { [key: string]: eslint.Rule.RuleModule };
-  id: string;
-}[] = [];
+const importedPlugins: EslintPlugin[] = [];
 const dirname = path.resolve();
 const nodeModules = 'node_modules/';
 
@@ -47,21 +49,26 @@ const getPlugins = fs
   );
 
 for (const plugin of getPlugins) {
-  let copyIt = plugin;
   if (plugin.includes('@')) {
-    const pluginDirectory = fs
+    const pluginDirectories = fs
       .readdirSync(path.join(dirname, nodeModules, plugin))
-      .find((read) => /plugin/u.test(read));
-    if (pluginDirectory) {
-      copyIt = path.join(dirname, nodeModules, plugin, pluginDirectory);
-    }
+      .filter((read) => /plugin/u.test(read));
+    pluginDirectories.forEach((pluginDirectory) => {
+      const scopedPlugin = path.join(
+        dirname,
+        nodeModules,
+        plugin,
+        pluginDirectory,
+      );
+      const imported = require(scopedPlugin) as EslintPlugin;
+      imported.id = scopedPlugin.replace(path.join(dirname, nodeModules), '');
+      importedPlugins.push(imported);
+    });
+  } else {
+    const imported = require(plugin) as EslintPlugin;
+    imported.id = plugin;
+    importedPlugins.push(imported);
   }
-  const imported = require(copyIt) as {
-    rules: { [key: string]: eslint.Rule.RuleModule };
-    id: string;
-  };
-  imported.id = plugin;
-  importedPlugins.push(imported);
 }
 
 for (const plugin of importedPlugins) {
@@ -69,7 +76,8 @@ for (const plugin of importedPlugins) {
   const pluginId = plugin.id;
   if (pluginId) {
     const pluginName = pluginId.includes('@')
-      ? pluginId.split('/')[0]
+      ? // convert `@angular-eslint/eslint-plugin` -> `@angular-eslint` and `@angular-eslint/eslint-plugin-template` -> `@angular-eslint/template`
+        pluginId.replace(/eslint-plugin(-|)/u, '').replace(/\/$/, '')
       : pluginId.replace(/^eslint-plugin-/u, '');
     for (const rule of Object.keys(pluginRules || {})) {
       if (rule) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     },
   },
 
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "lib"]
 }


### PR DESCRIPTION
Currently this plugin does not work with `@angular-eslint/eslint-plugin-template` as it thinks the rule names are `@angular-eslint/eqeqeq` and not `@angular-eslint/template/eqeqeq`. 

This PR adds a fix for this behaviour so now `disable-autofix/@angular-eslint/template/eqeqeq` will work 😄 