### PR TITLE
use relative module path instead of absolute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-disable-autofix",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Disable ESLint autofix (--fix) for specified rules",
   "scripts": {
     "fix": "eslint --fix '**/*'",

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -57,12 +57,7 @@ for (const plugin of getPlugins) {
       .readdirSync(path.join(dirname, nodeModules, plugin))
       .filter((read) => /plugin/u.test(read));
     for (const pluginDirectory of pluginDirectories) {
-      const scopedPlugin = path.join(
-        dirname,
-        nodeModules,
-        plugin,
-        pluginDirectory,
-      );
+      const scopedPlugin = path.join(plugin, pluginDirectory);
       const imported = require(scopedPlugin) as EslintPlugin;
       imported.id = scopedPlugin.replace(path.join(dirname, nodeModules), '');
       importedPlugins.push(imported);


### PR DESCRIPTION
this fixes resolution of the newer typescript-eslint packages on my system