### PR TITLE
make lodash a dependency instead of devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "app-root-path": "^3.1.0",
         "eslint": "^8.50.0",
-        "eslint-rule-composer": "^0.3.0"
+        "eslint-rule-composer": "^0.3.0",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@types/eslint": "^8.44.3",
@@ -19,7 +20,6 @@
         "@types/lodash": "^4.14.199",
         "eslint-plugin-unicorn": "^48.0.1",
         "jest": "^29.7.0",
-        "lodash": "^4.17.21",
         "mikey-pro": "^6.5.13",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
@@ -8322,8 +8322,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "app-root-path": "^3.1.0",
     "eslint": "^8.50.0",
-    "eslint-rule-composer": "^0.3.0"
+    "eslint-rule-composer": "^0.3.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/eslint": "^8.44.3",
@@ -24,7 +25,6 @@
     "@types/lodash": "^4.14.199",
     "eslint-plugin-unicorn": "^48.0.1",
     "jest": "^29.7.0",
-    "lodash": "^4.17.21",
     "mikey-pro": "^6.5.13",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
It's being used in https://github.com/chiefmikey/eslint-plugin-disable-autofix/blob/main/src/index.ts#L7.

If this plugin is installed as a devDependency, lodash will be a transitive devDependency and not installed (unless lodash is installed by something else). 

If that happens this plugin breaks eslint with `"Error: Failed to load plugin 'disable-autofix' declared in '.eslintrc.yml': Cannot find module 'lodash'"`

