### PR TITLE
fix: always use linux style separator to get the scoped plugin name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ for (const plugin of eslintPlugins) {
       .readdirSync(path.join(dirname, nodeModules, plugin))
       .filter((read) => /plugin/u.test(read));
     for (const pluginDirectory of pluginDirectories) {
-      const scopedPlugin = path.join(plugin, pluginDirectory);
+      const scopedPlugin = path.posix.join(plugin, pluginDirectory);
       const importedPlugin = require(scopedPlugin) as EslintPlugin;
       importedPlugin.id = scopedPlugin.replace(
         path.join(dirname, nodeModules),


### PR DESCRIPTION
Hello!

On Windows, the plugin "scope" part of the name and its "normal" part of the name are joined using `path.join` method. Because of that, `/` in package name is replaced with `\` which causes `require` to fail to resolve the module. For instance, `@typescript-eslint/eslint-plugin` becomes `@typescript-eslint\eslint-plugin` and the following error occurs:

```
Failed to load plugin 'disable-autofix' declared in '.eslintrc.cjs': Cannot find module '@typescript-eslint\eslint-plugin'
```

This tiny patch replaces `path.join` with [`path.posix.join`](https://nodejs.org/docs/latest-v18.x/api/path.html#pathposix) to ensure `\` is not used as a delimiter.