### PR TITLE
Fix scoped package identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .yalc
 lib
+node_modules
+dist

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const eslintPlugins = fs
   .filter(
     (plugin) =>
       (plugin.startsWith('eslint-plugin') ||
-        (plugin.startsWith('@') && /eslint/u.test(plugin))) &&
+        plugin.startsWith('@')) &&
       plugin !== 'eslint-plugin-disable-autofix' &&
       plugin !== '@eslint',
   );
@@ -93,7 +93,7 @@ for (const plugin of eslintPlugins) {
   if (plugin.includes('@')) {
     const pluginDirectories = fs
       .readdirSync(path.join(dirname, nodeModules, plugin))
-      .filter((read) => /plugin/u.test(read));
+      .filter((read) => read.startsWith("eslint-plugin"));
     for (const pluginDirectory of pluginDirectories) {
       const scopedPlugin = path.posix.join(plugin, pluginDirectory);
       const importedPlugin = require(scopedPlugin) as EslintPlugin;


### PR DESCRIPTION
The conditions that were being checked previously to find eslint-plugins in scoped packages was incorrect.

Updated plugin to use the naming requirements mentioned here: https://eslint.org/docs/latest/extend/plugins#name-a-plugin

Example of eslint-plugin which wasn't previously getting picked up before this change. https://www.npmjs.com/package/@nx/eslint-plugin