### PR TITLE
fix: Ignore '@types' modules to prevent 'Cannot find module' error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ const eslintPlugins = fs
   .filter(
     (plugin) =>
       (plugin.startsWith('eslint-plugin') || plugin.startsWith('@')) &&
+      !plugin.startsWith('@types') &&
       plugin !== 'eslint-plugin-disable-autofix' &&
       plugin !== '@eslint',
   );


### PR DESCRIPTION
The `@types` modules do not contain javascript files, only type definitions. This causes the error `Cannot find module` when using this plugin with an `@types` definition for an ESLint plugin, e.g. `eslint-plugin-security` with `@types/eslint-plugin-security`.

This PR ignores modules that start with `@types`, to prevent trying to load the `@types` modules which have nothing to load. 