### PR TITLE
feat: Emit typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "5.0.1",
   "description": "Disable autofix for ESLint rules without turning them off",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && sed -i '' -e 's/exports\\.default/module.exports/g' ./dist/index.js",
-    "gh-build": "tsc -p tsconfig.build.json && sed -i -e 's/exports\\.default/module.exports/g' ./dist/index.js",
+    "build": "tsc -p tsconfig.build.json && sed -i '' -e 's/exports\\.default/module.exports/g' ./dist/index.js && sed -i '' -e 's/export default/export =/g' ./dist/index.d.ts",
+    "gh-build": "tsc -p tsconfig.build.json && sed -i -e 's/exports\\.default/module.exports/g' ./dist/index.js && sed -i -e 's/export default/export =/g' ./dist/index.d.ts",
     "gh-test": "npm run gh-build && jest tests/v9",
     "gh-test-v8": "npm run gh-build && jest tests/v8",
     "major": "npm version major; cd dist && npm version major",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,6 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true,
+    "declaration": true,
     "noEmit": false,
     "noImplicitAny": true,
     "removeComments": true,


### PR DESCRIPTION
When running `npm run build`, this will create an `index.d.ts` file in the `dist` folder with the types for this module.  You just have to make sure it's included in the package when publishing. 

* Resolves #53 

See this article for details on the exports modification of the .d.ts file: https://blog.andrewbran.ch/default-exports-in-commonjs-libraries/